### PR TITLE
Fix section edit handling

### DIFF
--- a/action.php
+++ b/action.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Action part of the DokuTesaer plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author Michael Hamann <michael@content-space.de>
+ */
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+/**
+ * Action class of the DokuTeaser plugin, handles section edit buttons
+ */
+class action_plugin_dokuteaser extends DokuWiki_Action_Plugin {
+    /**
+     * register the eventhandlers
+     *
+     * @param Doku_Event_Handler $controller The even controller
+     */
+    function register(&$controller){
+        $controller->register_hook('HTML_SECEDIT_BUTTON', 'BEFORE', $this, 'handle_secedit_button');
+    }
+
+    /**
+     * Handle section edit buttons, prevents section buttons inside the DokuTeaser plugin from being rendered
+     *
+     * @param Doku_Event $event The event object
+     * @param array      $args Parameters for the event
+     */
+    public function handle_secedit_button($event, $args) {
+        // counter of the number of currently opened wraps
+        static $wraps = 0;
+        $data = $event->data;
+
+        if ($data['target'] == 'plugin_dokuteaser_start') {
+            ++$wraps;
+        } elseif ($data['target'] == 'plugin_dokuteaser_end') {
+            --$wraps;
+        } elseif ($wraps > 0 && $data['target'] == 'section') {
+            $event->preventDefault();
+            $event->stopPropagation();
+            $event->result = '';
+        }
+    }
+
+}

--- a/syntax/closesection.php
+++ b/syntax/closesection.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Section close helper of the DokuTeaser Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Michael Hamann <michael@content-space.de>
+ */
+
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+
+class syntax_plugin_dokuteaser_closesection extends DokuWiki_Syntax_Plugin {
+
+    function getType(){ return 'substition';}
+    function getPType(){ return 'block';}
+    function getSort(){ return 195; }
+
+    /**
+     * Dummy handler, this syntax part has no syntax but is directly added to the instructions by the div syntax
+     */
+    function handle($match, $state, $pos, &$handler){
+    }
+
+    /**
+     * Create output
+     */
+    function render($mode, &$renderer, $indata) {
+        if($mode == 'xhtml'){
+            /** @var Doku_Renderer_xhtml $renderer */
+            $renderer->finishSectionEdit();
+            return true;
+        }
+        return false;
+    }
+
+
+}
+


### PR DESCRIPTION
This removes section edits inside the dokuteaser sections. The next section edit button after the dokuteaser content covers the whole dokuteaser content now.
